### PR TITLE
ShEx for Module "Care Pathway" and "Disease History and Diagnosis"

### DIFF
--- a/shex/sio-model/carePathway.shex
+++ b/shex/sio-model/carePathway.shex
@@ -1,0 +1,11 @@
+PREFIX : <http://purl.org/ejp-rd/cde/v020/shex/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX sio: <http://semanticscience.org/resource/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:processShape IRI {
+  a [sio:process];
+  a [obo:NCIT_C142427];
+  a [obo:NCIT_C159705];
+  sio:start-date xsd:dateTime
+}

--- a/shex/sio-model/diseaseHistoryAndDiagnosisShape_SIO.shex
+++ b/shex/sio-model/diseaseHistoryAndDiagnosisShape_SIO.shex
@@ -1,0 +1,74 @@
+PREFIX : <http://purl.org/ejp-rd/cde/v020/shex/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX sio: <http://semanticscience.org/resource/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+:personShape IRI {
+  a [sio:person];
+  obo:RO_0002162 @:taxonShape;
+  sio:has-role @:personRoleShape;
+  sio:has-quality @:symptomOnsetQualityShape;
+  sio:has-quality @:birthDateQualityShape
+}
+
+:taxonShape IRI {
+  a [obo:NCBITaxon_9606]
+}
+
+:personRoleShape IRI {
+  a [sio:patient-role];
+  sio:is-realized-in @:medicalDiagnosisProcessShape
+}
+
+:medicalDiagnosisProcessShape IRI {
+  a [sio:medical-diagnosis];
+  dct:date  xsd:dateTime;
+  sio:has-output @:diagnosisShape;
+  prov:wasInformedBy @:symptomOnsetProcessShape
+}
+
+:diagnosisShape IRI {
+  a [sio:realizable-entity];
+  a IRI /^http:\/\/www.orpha.net\/ORDO\/Orphanet_/
+}
+
+:symptomOnsetQualityShape IRI {
+  a [obo:NCIT_C124353];
+  (sio:has-measurement-value @:symptomOnsetDateValueShape |
+  sio:is-base-for @:symptomOnsetTypeValueShape
+  )
+}
+
+:birthDateQualityShape IRI {
+  a [obo:NCIT_C68615];
+  sio:has-measurement-value @:birthDateOutputShape
+}
+
+:birthDateOutputShape IRI {
+  a [sio:realizable-entity];
+  sio:has-value xsd:dateTime
+}
+
+:symptomOnsetDateValueShape IRI {
+  a [sio:measurement-value];
+  sio:has-value xsd:dateTime
+}
+
+:symptomOnsetTypeValueShape IRI {
+  a [obo:HP_0030674 obo:HP_0003577 obo:NCIT_C124294]
+}
+
+:symptomOnsetProcessShape IRI {
+  (sio:has-output @:symptomOnsetDateValueShape|
+  sio:has-output @:symptomOnsetTypeValueShape
+  );
+  dct:date xsd:dateTime
+}
+
+obo:RO_0002162 rdfs:label "in taxon" .
+
+
+
+


### PR DESCRIPTION
Dear all, 

I create ShEx for the modules "care pathway" and "disease history and diagnosis", which comply with the diagrams (https://github.com/ejp-rd-vp/CDE-semantic-model/wiki/Care-pathway-SIO and https://github.com/ejp-rd-vp/CDE-semantic-model/blob/develop/images/5_Disease_history_and_diagnosis_SIO.png). 

Thank @markwilkinson for your "example turtle". I validate it against the ShEx, which turns out some conflicts:


| What  | ShEx (Diagram) | Turtle| How is it in Core Model|
| ------------- | ------------- |-----|-----|
| Type of Person Node | sio:person  | sio:patient| sio:person is used|
| Type of Patient Role Node | sio:patient-role|sio:patient-role, sio:role| only sio:patient-role is used|
|Relationship between bithDateQualityShape and its output| sio:has-measurement-value| sio:has-measurement-value| In diagrams of other modules, sio:is-base-for is used|
|Type of birthDateOutputShape| sio:realizable-entity|sio:measurement_value|In diagrams of other modules, sio:realizable-entity is used|
|Medical Diagnosis| as a mandatory node connecting to role and its output| Missing| Such inconsistency leads to "missing-property rrrors" from Role instances|

Look forward to suggestions and reviews.